### PR TITLE
Prevent refresh race conditions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ jdk: oraclejdk8
 env:
   global:
     - MALLOC_ARENA_MAX=2
+    - ADB_INSTALL_TIMEOUT=10
   matrix:
     - ANDROID_TARGET=android-22  ANDROID_ABI=armeabi-v7a
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ env:
 android:
   components:
     - tools
-    - build-tools-23.0.2
-    - android-23
+    - build-tools-23.0.3
+    - android-24
     - android-22
     - sys-img-armeabi-v7a-android-22
     - extra-google-m2repository

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ android:
     - build-tools-23.0.3
     - android-24
     - android-22
+    - android-23
     - sys-img-armeabi-v7a-android-22
     - extra-google-m2repository
     - extra-android-m2repository

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.2.3'
+        classpath 'com.android.tools.build:gradle:2.1.3'
         classpath 'me.tatarka:gradle-retrolambda:2.5.0'
         classpath 'org.codehaus.groovy:gradle-groovy-android-plugin:0.3.6'
         classpath 'com.github.dcendents:android-maven-plugin:1.2'
@@ -20,8 +20,8 @@ buildscript {
 group = 'com.github.rheinfabrik'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    compileSdkVersion 24
+    buildToolsVersion "23.0.3"
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -37,8 +37,8 @@ android {
     defaultConfig {
         minSdkVersion 9
         targetSdkVersion 23
-        versionCode 104
-        versionName "1.0.4"
+        versionCode 105
+        versionName "1.0.5"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 

--- a/library/src/androidTest/groovy/de/rheinfabrik/heimdall/OAuth2AccessTokenManagerSpecs.groovy
+++ b/library/src/androidTest/groovy/de/rheinfabrik/heimdall/OAuth2AccessTokenManagerSpecs.groovy
@@ -5,6 +5,8 @@ import de.rheinfabrik.heimdall.grants.OAuth2Grant
 import de.rheinfabrik.heimdall.grants.OAuth2RefreshAccessTokenGrant
 import spock.lang.Title
 
+import java.util.concurrent.TimeUnit
+
 import static rx.Single.just
 
 @Title("Tests for the constructor of the OAuth2AccessTokenManager class")
@@ -137,6 +139,39 @@ class OAuth2AccessTokenManagerGetStorageSpecs extends AndroidSpecification {
 class OAuth2AccessTokenManagerGetValidAccessTokenSpecs extends AndroidSpecification {
 
     // Scenarios
+
+    def "it should only request a new valid token ONCE"() {
+
+        given: "An expired OAuth2AccessToken"
+            OAuth2AccessToken accessToken = Mock(OAuth2AccessToken)
+            accessToken.refreshToken = "rt"
+            accessToken.isExpired() >> true
+
+        and: "A mock storage emitting that token"
+            OAuth2AccessTokenStorage storage = Mock(OAuth2AccessTokenStorage)
+            storage.getStoredAccessToken() >> just(accessToken).delay(1, TimeUnit.SECONDS)
+
+        and: "An OAuth2AccessTokenManager with that storage"
+            OAuth2AccessTokenManager tokenManager = new OAuth2AccessTokenManager<OAuth2AccessToken>(storage)
+
+        and: "A mock grant"
+            OAuth2RefreshAccessTokenGrant grant = Mock(OAuth2RefreshAccessTokenGrant)
+
+        when: "I ask for a valid access token"
+            tokenManager.getValidAccessToken(grant).subscribe()
+
+        and: "I ask again"
+            tokenManager.getValidAccessToken(grant).subscribe()
+
+        and: "I wait 2 seconds"
+            sleep(2000)
+
+        and: "I ask again"
+            tokenManager.getValidAccessToken(grant).subscribe()
+
+        then: "The refresh grant is asked for a new token TWICE"
+            2 * grant.grantNewAccessToken() >> just(accessToken)
+    }
 
     def "it should throw an IllegalArgumentException when the refreshAccessTokenGrant parameter is null"() {
 

--- a/library/src/androidTest/groovy/de/rheinfabrik/heimdall/OAuth2AccessTokenManagerSpecs.groovy
+++ b/library/src/androidTest/groovy/de/rheinfabrik/heimdall/OAuth2AccessTokenManagerSpecs.groovy
@@ -170,7 +170,7 @@ class OAuth2AccessTokenManagerGetValidAccessTokenSpecs extends AndroidSpecificat
             tokenManager.getValidAccessToken(grant).subscribe()
 
         then: "The refresh grant is asked for a new token TWICE"
-            2 * grant.grantNewAccessToken() >> just(accessToken)
+            2 * grant.grantNewAccessToken() >> just(accessToken) >> just(accessToken)
     }
 
     def "it should throw an IllegalArgumentException when the refreshAccessTokenGrant parameter is null"() {

--- a/library/src/main/java/de/rheinfabrik/heimdall/OAuth2AccessTokenManager.java
+++ b/library/src/main/java/de/rheinfabrik/heimdall/OAuth2AccessTokenManager.java
@@ -4,8 +4,8 @@ import java.util.Calendar;
 
 import de.rheinfabrik.heimdall.grants.OAuth2Grant;
 import de.rheinfabrik.heimdall.grants.OAuth2RefreshAccessTokenGrant;
+import rx.Observable;
 import rx.Single;
-import rx.functions.Func1;
 
 import static rx.Single.error;
 
@@ -20,6 +20,7 @@ public class OAuth2AccessTokenManager<TAccessToken extends OAuth2AccessToken> {
     // Members
 
     private final OAuth2AccessTokenStorage<TAccessToken> mStorage;
+    private Observable<TAccessToken> mTokenObservable;
 
     // Constructor
 
@@ -71,17 +72,25 @@ public class OAuth2AccessTokenManager<TAccessToken extends OAuth2AccessToken> {
             throw new IllegalArgumentException("Grant MUST NOT be null.");
         }
 
-        return grant
-                .grantNewAccessToken()
-                .doOnSuccess(accessToken -> {
-                    if (accessToken.expiresIn != null) {
-                        Calendar expirationDate = (Calendar) calendar.clone();
-                        expirationDate.add(Calendar.SECOND, accessToken.expiresIn);
-                        accessToken.expirationDate = expirationDate;
-                    }
+        if (mTokenObservable == null) {
+            mTokenObservable = grant
+                    .grantNewAccessToken()
+                    .doOnSuccess(accessToken -> {
+                        if (accessToken.expiresIn != null) {
+                            Calendar expirationDate = (Calendar) calendar.clone();
+                            expirationDate.add(Calendar.SECOND, accessToken.expiresIn);
+                            accessToken.expirationDate = expirationDate;
+                        }
 
-                    mStorage.storeAccessToken(accessToken);
-                });
+                        mStorage.storeAccessToken(accessToken);
+
+                        mTokenObservable = null;
+                    })
+                    .toObservable()
+                    .cache();
+        }
+
+        return mTokenObservable.toSingle();
     }
 
     /**

--- a/library/src/main/java/de/rheinfabrik/heimdall/OAuth2AccessTokenManager.java
+++ b/library/src/main/java/de/rheinfabrik/heimdall/OAuth2AccessTokenManager.java
@@ -20,7 +20,7 @@ public class OAuth2AccessTokenManager<TAccessToken extends OAuth2AccessToken> {
     // Members
 
     private final OAuth2AccessTokenStorage<TAccessToken> mStorage;
-    private Observable<TAccessToken> mTokenObservable;
+    private Single<TAccessToken> mTokenSingle;
 
     // Constructor
 
@@ -72,8 +72,8 @@ public class OAuth2AccessTokenManager<TAccessToken extends OAuth2AccessToken> {
             throw new IllegalArgumentException("Grant MUST NOT be null.");
         }
 
-        if (mTokenObservable == null) {
-            mTokenObservable = grant
+        if (mTokenSingle == null) {
+            mTokenSingle = grant
                     .grantNewAccessToken()
                     .doOnSuccess(accessToken -> {
                         if (accessToken.expiresIn != null) {
@@ -84,13 +84,11 @@ public class OAuth2AccessTokenManager<TAccessToken extends OAuth2AccessToken> {
 
                         mStorage.storeAccessToken(accessToken);
 
-                        mTokenObservable = null;
-                    })
-                    .toObservable()
-                    .cache();
+                        mTokenSingle = null;
+                    });
         }
 
-        return mTokenObservable.toSingle();
+        return mTokenSingle;
     }
 
     /**

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -12,13 +12,13 @@ buildscript {
 }
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    compileSdkVersion 24
+    buildToolsVersion "23.0.3"
 
     defaultConfig {
         applicationId "de.rheinfabrik.heimdall"
         minSdkVersion 15
-        targetSdkVersion 23
+        targetSdkVersion 24
         versionCode 1
         versionName "1.0"
     }


### PR DESCRIPTION
**NOTE**
This is pretty similar to the bug found in the [iOS version of Heimdallr](https://github.com/trivago/Heimdallr.swift/pull/93)

**Description**
When calling ```getValidAccessToken()``` multiple times it might query any amount of refresh calls. This might confuse/flood the server and the app behaving not as expected.

**Solution**
On ```grantNewAccessToken``` which is called from ```getValidAccessToken```  we check if there already is a request to grab the access token. If so we simply subscribe to it. Only if there is none we create a new one.