### PR TITLE
Feature/really fix raice conditions

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -38,7 +38,7 @@ android {
         minSdkVersion 9
         targetSdkVersion 23
         versionCode 105
-        versionName "1.0.5"
+        versionName "1.0.6"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 

--- a/library/src/main/java/de/rheinfabrik/heimdall/OAuth2AccessTokenManager.java
+++ b/library/src/main/java/de/rheinfabrik/heimdall/OAuth2AccessTokenManager.java
@@ -4,7 +4,6 @@ import java.util.Calendar;
 
 import de.rheinfabrik.heimdall.grants.OAuth2Grant;
 import de.rheinfabrik.heimdall.grants.OAuth2RefreshAccessTokenGrant;
-import rx.Observable;
 import rx.Single;
 
 import static rx.Single.error;
@@ -85,7 +84,7 @@ public class OAuth2AccessTokenManager<TAccessToken extends OAuth2AccessToken> {
                         mStorage.storeAccessToken(accessToken);
 
                         mTokenSingle = null;
-                    });
+                    }).toObservable().cache().toSingle();
         }
 
         return mTokenSingle;


### PR DESCRIPTION
The previous solution was not working correctly. We adopt it to use the RXJava .cache() operator to ensure the grantNewAccessToken request is only queried once.